### PR TITLE
GPII-3290: Moved grunt to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
             "url": "https://github.com/GPII/gpii-grunt-lint-all/blob/master/LICENSE-BSD-3-Clause"
         }
     ],
-    "engines": {
-        "node": ">= 0.8.0"
-    },
     "scripts": {
         "test": "node tests/all-tests.js"
     },
@@ -33,15 +30,15 @@
         "fluid-grunt-eslint": "18.1.2",
         "fluid-grunt-json5lint": "1.0.0",
         "fluid-resolve": "1.3.0",
-        "gpii-grunt-mdjson-lint": "1.0.0-dev.20180622T125519Z.0d942ed",
-        "grunt": "~0.4.5",
+        "gpii-grunt-mdjson-lint": "1.0.0",
         "grunt-jsonlint": "1.1.0",
         "grunt-lintspaces": "0.8.3",
-        "grunt-markdownlint": "1.1.6",
+        "grunt-markdownlint": "2.1.0",
         "json5": "1.0.1",
         "jsonlint": "1.6.3"
     },
     "devDependencies": {
+        "grunt": "1.0.3",
         "node-jqunit": "1.1.8"
     },
     "keywords": [


### PR DESCRIPTION
See [GPII-3290](https://issues.gpii.net/browse/GPII-3290) for details.