### PR TITLE
NOJIRA: use markdownlint-config-fluid instead of embedded config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "grunt-stylelint": "0.15.0",
         "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718",
         "json5": "2.1.3",
+        "markdownlint-config-fluid": "0.1.0",
         "strip-ansi": "6.0.0",
         "stylelint": "13.7.2",
         "stylelint-config-fluid": "0.1.0",

--- a/tasks/lint-all.js
+++ b/tasks/lint-all.js
@@ -1,5 +1,6 @@
 "use strict";
 var fluid = require("infusion");
+var grunt = require("grunt");
 
 require("../index");
 require("../src/load-npm-tasks-properly");
@@ -63,20 +64,7 @@ fluid.grunt.lintAll.defaults = {
     },
     markdownlint: {
         options: {
-            config: {
-                // See https://github.com/DavidAnson/markdownlint#rules--aliases for rule names and meanings.
-                "no-duplicate-header": false, // We use duplicate nested headers, as in section 1 and 2 both have the same sub-section name.
-                "no-trailing-punctuation": false,  // This catches headings that are questions, which seems wrong.
-                "header-style": { style: "atx" }, // Although we use a mix, in discussion with various team members, we agreed to try this for now.
-                "no-inline-html": false, // Obviously we need HTML
-                "line-length": {
-                    line_length: 120,
-                    tables:      false,
-                    code_blocks: false
-                },
-                "code-block-style": false, // Allow both fenced and indented styles
-                "ol-prefix": {style: "ordered"} // 1. 2. 3. etc
-            }
+            config: grunt.file.readJSON("./node_modules/markdownlint-config-fluid/.markdownlintrc.json")
         }
     },
     mdjsonlint: {},


### PR DESCRIPTION
This PR uses the new [markdownlint-config-fluid](https://github.com/fluid-project/markdownlint-config-fluid/) shareable configuration for Markdownlint instead of directly configuring the linter in the task.